### PR TITLE
Fix: example to use chunkExtractor, typescript version up

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -24,7 +24,7 @@
     "@types/react-dom": "^16.9.3",
     "@types/react-router-dom": "^5.1.2",
     "ts-loader": "^6.2.1",
-    "typescript": "^3.6.4",
+    "typescript": "^3.7.2",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.10",
     "webpack-merge": "^4.2.2"

--- a/example/src/server.tsx
+++ b/example/src/server.tsx
@@ -39,7 +39,12 @@ app.get("*", async (req, res) => {
     </StaticRouter>
   );
 
-  const content = renderToString(App);
+  const content = renderToString(
+    extractor.collectChunks(
+      App
+    )
+  );
+
   res.status(200).end(html({ content }));
 });
 

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3345,10 +3345,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.6.4:
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
-  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
+typescript@^3.7.2:
+  version "3.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
+  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
 union-value@^1.0.0:
   version "1.0.1"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prettier": "^1.18.2",
     "pretty-quick": "^2.0.0",
     "ts-jest": "^24.1.0",
-    "typescript": "^3.6.4"
+    "typescript": "^3.7.2"
   },
   "husky": {
     "hooks": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3708,10 +3708,10 @@ type-fest@^0.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
-typescript@^3.6.4:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@^3.7.2:
+  version "3.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
+  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
 uglify-js@^3.1.4:
   version "3.6.7"


### PR DESCRIPTION
Hello @Quramy,
I tried to use `loadable-ts-tranformer` on my project, but i met `Invariant` error like https://github.com/Quramy/loadable-ts-transformer/issues/4.
It was able to resolve the problem, but i'm not sure that this is a right patch because I'm new at typescript transformers. Please have a look at it

## Related Issue
https://github.com/Quramy/loadable-ts-transformer/issues/4

## Issue Summary
- Example's `server.tsx` doesn't use `ChunkExtractor`. I fixed it to use it
- Example code had `Invariant` error like https://github.com/Quramy/loadable-ts-transformer/issues/4, and it was resolved after typescript version is changed to `^3.7.2` (actually `3.9.5`)

## Issue details
- On typescript 3.6.2 version, the loadable transformer seems to traverse the only siblings of `SourceFile`.  

### Test code
```typescript
export function loadableTransformer(ctx: ts.TransformationContext) {
  function visitNode(node: ts.Node): ts.Node {
    // console log for watching AST traverse
    console.log('node.getText', node.getText(), node.kind, ts.SyntaxKind[node.kind])
    if (!isLoadableNode(node)) return ts.visitEachChild(node, visitNode, ctx);

    const funcNode = getFuncNode(node);
    if (!funcNode) return node;

    // Collect dynamic import call expressions such as `import('./foo')`
    const imports = collectImports(node, ctx);

    // Ignore loadable function that does not have any "import" call
    if (imports.length === 0) return node;

    // Multiple imports call is not supported
    if (imports.length > 1) {
      throw new Error('loadable: multiple import calls inside `loadable()` function are not supported.');
    }

    const [callNode] = imports;

    const obj = ts.createObjectLiteral(
      [
        chunkNameProperty({ ctx, callNode, funcNode }),
        isReadyProperty(ctx),
        requireAsyncProperty(funcNode),
        requireSyncProperty(ctx),
        resolveProperty(callNode),
      ],
      true,
    );
    return ts.updateCall(node, node.expression, undefined, [obj]);
  }

  return (source: ts.SourceFile) => ts.updateSourceFileNode(source, ts.visitNodes(source.statements, visitNode));
}
```

### Console output
- **Problem**: The siblings of `sourceFile` node are only traversed, not all AST nodes
- Wrong node kind numbers are allocated
  - e.g> `node.getText import React from "react"; 250 CaseBlock` : not `CaseBlock` => toBe `ImportDeclaration`

```
example user$ yarn start
yarn run v1.17.3
$ yarn build && node dist-server/server.js
$ webpack --config webpack.config.client.js --mode production && webpack --config webpack.config.server.js --mode development
node.getText import React from "react"; 250 CaseBlock
node.getText import { loadableReady } from "@loadable/component" 250 CaseBlock
node.getText import { hydrate } from "react-dom"; 250 CaseBlock
node.getText import { BrowserRouter } from "react-router-dom"; 250 CaseBlock
node.getText import Routes from "./routes"; 250 CaseBlock
node.getText function bootstrap() {
  const elm = document.getElementById("app");
  if (!elm) return;
  hydrate((
    <BrowserRouter>
      <Routes />
    </BrowserRouter>
  ), elm);
} 240 LastStatement
node.getText loadableReady(() => bootstrap()); 222 Block
node.getText import React from "react"; 250 CaseBlock
node.getText import { Route } from "react-router-dom"; 250 CaseBlock
node.getText import loadable from "@loadable/component"; 250 CaseBlock
node.getText const Home = loadable(() => import("./components/home")); 220 TemplateSpan
node.getText const About = loadable(() => import("./components/about")); 220 TemplateSpan
node.getText export default () => (
  <>
    <Route path="/" exact component={Home} />
    <Route path="/about" exact component={About} />
  </>
); 255 NamespaceImport
node.getText import React from "react"; 250 CaseBlock
node.getText import { Link } from "react-router-dom"; 250 CaseBlock
node.getText export default () => (
  <div>
    <h1>Home</h1>
    <nav>
      <ul>
        <li>
          <Link to="/about">About page</Link>
        </li>
      </ul>
    </nav>
  </div>
); 255 NamespaceImport
node.getText import React from "react"; 250 CaseBlock
node.getText import { Link } from "react-router-dom"; 250 CaseBlock
node.getText export default () => (
  <div>
    <h1>This is about page</h1>
    <nav>
      <ul>
        <li>
          <Link to="/">Home</Link>
        </li>
      </ul>
    </nav>
  </div>
); 255 NamespaceImport
Hash: e62d8cc53e92cc2944df
Version: webpack 4.41.2
Time: 937ms
Built at: 2020-06-05 16:14:15
                         Asset       Size  Chunks                         Chunk Names
     2.98ee86182d38a43522c8.js  377 bytes       2  [emitted] [immutable]
     3.07dc95702d0ec2024ff8.js  374 bytes       3  [emitted] [immutable]
           loadable-stats.json   1.86 KiB          [emitted]
  main.9a8cceab24668bb5d7c3.js    2.8 KiB       0  [emitted] [immutable]  main
vendor.4ccaee456d59dc5cefd5.js    157 KiB       1  [emitted] [immutable]  vendor
Entrypoint main = vendor.4ccaee456d59dc5cefd5.js main.9a8cceab24668bb5d7c3.js
 [4] ./node_modules/history/esm/history.js + 2 modules 30.6 KiB {1} [built]
     |    3 modules
 [6] ./node_modules/react-router/esm/react-router.js + 1 modules 29.2 KiB {1} [built]
     |    2 modules
 [8] ./node_modules/@loadable/component/dist/loadable.esm.js + 1 modules 12.2 KiB {1} [built]
     |    2 modules
[25] (webpack)/buildin/global.js 472 bytes {1} [built]
[27] ./src/client.tsx + 1 modules 922 bytes {0} [built]
     | ./src/client.tsx 440 bytes [built]
     | ./src/routes.tsx 457 bytes [built]
    + 25 hidden modules
node.getText import React from "react"; 250 CaseBlock
node.getText import path from "path"; 250 CaseBlock
node.getText import { ChunkExtractor } from "@loadable/server"; 250 CaseBlock
node.getText import express from "express"; 250 CaseBlock
node.getText import { renderToString, renderToStaticMarkup } from "react-dom/server"; 250 CaseBlock
node.getText import { StaticRouter } from "react-router-dom"; 250 CaseBlock
node.getText import Routes from "./routes"; 250 CaseBlock
node.getText const prjBase = process.cwd(); 220 TemplateSpan
node.getText const extractor = new ChunkExtractor({
  entrypoints: ["main"],
  publicPath: "/assets/",
  statsFile: path.resolve(prjBase, "public/loadable-stats.json"),
}); 220 TemplateSpan
node.getText const app = express(); 220 TemplateSpan
node.getText const port = process.env.PORT || 3000; 220 TemplateSpan
node.getText const html = ({ content }: { content: string }) => `<!doctype html>
<html>
  <body>
    <div id="app">${content}</div>
    ${extractor.getScriptTags()}
  </body>
</html>`; 220 TemplateSpan
node.getText app.use("/assets", express.static(path.resolve(prjBase, "public"))); 222 Block
node.getText app.get("*", async (req, res) => {

  const context = {};
  const App = (
    <StaticRouter location={req.url} context={context}>
      <Routes />
    </StaticRouter>
  );

  const content = renderToString(
    extractor.collectChunks(
      App
    )
  );

  res.status(200).end(html({ content }));
}); 222 Block
node.getText app.listen(port, () => console.log(
  `React SSR server is now running on http://localhost:${port}`
)); 222 Block
node.getText import React from "react"; 250 CaseBlock
node.getText import { Route } from "react-router-dom"; 250 CaseBlock
node.getText import loadable from "@loadable/component"; 250 CaseBlock
node.getText const Home = loadable(() => import("./components/home")); 220 TemplateSpan
node.getText const About = loadable(() => import("./components/about")); 220 TemplateSpan
node.getText export default () => (
  <>
    <Route path="/" exact component={Home} />
    <Route path="/about" exact component={About} />
  </>
); 255 NamespaceImport
node.getText import React from "react"; 250 CaseBlock
node.getText import { Link } from "react-router-dom"; 250 CaseBlock
node.getText export default () => (
  <div>
    <h1>This is about page</h1>
    <nav>
      <ul>
        <li>
          <Link to="/">Home</Link>
        </li>
      </ul>
    </nav>
  </div>
); 255 NamespaceImport
node.getText import React from "react"; 250 CaseBlock
node.getText import { Link } from "react-router-dom"; 250 CaseBlock
node.getText export default () => (
  <div>
    <h1>Home</h1>
    <nav>
      <ul>
        <li>
          <Link to="/about">About page</Link>
        </li>
      </ul>
    </nav>
  </div>
); 255 NamespaceImport
Hash: afc7ba4581746c98b312
Version: webpack 4.41.2
Time: 1560ms
Built at: 2020-06-05 16:14:18
    Asset      Size  Chunks             Chunk Names
     0.js  1.52 KiB       0  [emitted]
     1.js  1.51 KiB       1  [emitted]
server.js  1.62 MiB  server  [emitted]  server
Entrypoint server = server.js
[./node_modules/express/lib sync recursive] ./node_modules/express/lib sync 160 bytes {server} [built]
[./node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {server} [built]
[./src/routes.tsx] 457 bytes {server} [built]
[./src/server.tsx] 1.83 KiB {server} [built]
[buffer] external "buffer" 42 bytes {server} [built]
[crypto] external "crypto" 42 bytes {server} [built]
[events] external "events" 42 bytes {server} [built]
[fs] external "fs" 42 bytes {server} [built]
[http] external "http" 42 bytes {server} [built]
[net] external "net" 42 bytes {server} [built]
[path] external "path" 42 bytes {server} [built]
[querystring] external "querystring" 42 bytes {server} [built]
[stream] external "stream" 42 bytes {server} [built]
[url] external "url" 42 bytes {server} [built]
[util] external "util" 42 bytes {server} [built]
    + 283 hidden modules

WARNING in ./node_modules/express/lib/view.js 81:13-25
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/express/lib/application.js
 @ ./node_modules/express/lib/express.js
 @ ./node_modules/express/index.js
 @ ./src/server.tsx
React SSR server is now running on http://localhost:3000
```

